### PR TITLE
Read vite.config.js from project root path 

### DIFF
--- a/examples/vite.config.js
+++ b/examples/vite.config.js
@@ -1,0 +1,4 @@
+export default {
+  base: '/foo/',
+  publicDir: 'static',
+};

--- a/packages/quickpage/package-lock.json
+++ b/packages/quickpage/package-lock.json
@@ -74,10 +74,35 @@
                 }
             }
         },
+        "anymatch": {
+            "version": "3.1.2",
+            "resolved": "https://npm.shopee.io/anymatch/-/anymatch-3.1.2.tgz",
+            "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+            "dev": true,
+            "requires": {
+                "normalize-path": "^3.0.0",
+                "picomatch": "^2.0.4"
+            }
+        },
         "at-least-node": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
             "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
+        },
+        "binary-extensions": {
+            "version": "2.2.0",
+            "resolved": "https://npm.shopee.io/binary-extensions/-/binary-extensions-2.2.0.tgz",
+            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+            "dev": true
+        },
+        "braces": {
+            "version": "3.0.2",
+            "resolved": "https://npm.shopee.io/braces/-/braces-3.0.2.tgz",
+            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "dev": true,
+            "requires": {
+                "fill-range": "^7.0.1"
+            }
         },
         "chalk": {
             "version": "4.1.1",
@@ -128,6 +153,72 @@
                 }
             }
         },
+        "chokidar": {
+            "version": "3.5.1",
+            "resolved": "https://npm.shopee.io/chokidar/-/chokidar-3.5.1.tgz",
+            "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+            "dev": true,
+            "requires": {
+                "anymatch": "~3.1.1",
+                "braces": "~3.0.2",
+                "fsevents": "~2.3.1",
+                "glob-parent": "~5.1.0",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.5.0"
+            }
+        },
+        "colorette": {
+            "version": "1.2.2",
+            "resolved": "https://npm.shopee.io/colorette/-/colorette-1.2.2.tgz",
+            "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+            "dev": true
+        },
+        "copy-anything": {
+            "version": "2.0.3",
+            "resolved": "https://npm.shopee.io/copy-anything/-/copy-anything-2.0.3.tgz",
+            "integrity": "sha512-GK6QUtisv4fNS+XcI7shX0Gx9ORg7QqIznyfho79JTnX1XhLiyZHfftvGiziqzRiEi/Bjhgpi+D2o7HxJFPnDQ==",
+            "dev": true,
+            "requires": {
+                "is-what": "^3.12.0"
+            }
+        },
+        "debug": {
+            "version": "3.2.7",
+            "resolved": "https://npm.shopee.io/debug/-/debug-3.2.7.tgz",
+            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "ms": "^2.1.1"
+            }
+        },
+        "errno": {
+            "version": "0.1.8",
+            "resolved": "https://npm.shopee.io/errno/-/errno-0.1.8.tgz",
+            "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "prr": "~1.0.1"
+            }
+        },
+        "esbuild": {
+            "version": "0.11.22",
+            "resolved": "https://npm.shopee.io/esbuild/-/esbuild-0.11.22.tgz",
+            "integrity": "sha512-1e6BDytHzTxRlUOCe7M0+ZV5JqKARByHwz1iP5UNmxt2TEOyI8E/1gLLNCyaPjpXfCr1TThxTyFO9MjF5mFLvA==",
+            "dev": true
+        },
+        "fill-range": {
+            "version": "7.0.1",
+            "resolved": "https://npm.shopee.io/fill-range/-/fill-range-7.0.1.tgz",
+            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "dev": true,
+            "requires": {
+                "to-regex-range": "^5.0.1"
+            }
+        },
         "fs-extra": {
             "version": "9.1.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -139,10 +230,58 @@
                 "universalify": "^2.0.0"
             }
         },
+        "fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://npm.shopee.io/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "optional": true
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://npm.shopee.io/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
+        },
+        "glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://npm.shopee.io/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
+            "requires": {
+                "is-glob": "^4.0.1"
+            }
+        },
         "graceful-fs": {
             "version": "4.2.6",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
             "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+        },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://npm.shopee.io/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1"
+            }
+        },
+        "iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://npm.shopee.io/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            }
+        },
+        "image-size": {
+            "version": "0.5.5",
+            "resolved": "https://npm.shopee.io/image-size/-/image-size-0.5.5.tgz",
+            "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
+            "dev": true,
+            "optional": true
         },
         "inquirer": {
             "version": "8.0.0",
@@ -380,6 +519,51 @@
                 }
             }
         },
+        "is-binary-path": {
+            "version": "2.1.0",
+            "resolved": "https://npm.shopee.io/is-binary-path/-/is-binary-path-2.1.0.tgz",
+            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+            "dev": true,
+            "requires": {
+                "binary-extensions": "^2.0.0"
+            }
+        },
+        "is-core-module": {
+            "version": "2.4.0",
+            "resolved": "https://npm.shopee.io/is-core-module/-/is-core-module-2.4.0.tgz",
+            "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+            "dev": true,
+            "requires": {
+                "has": "^1.0.3"
+            }
+        },
+        "is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://npm.shopee.io/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "dev": true
+        },
+        "is-glob": {
+            "version": "4.0.1",
+            "resolved": "https://npm.shopee.io/is-glob/-/is-glob-4.0.1.tgz",
+            "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+            "dev": true,
+            "requires": {
+                "is-extglob": "^2.1.1"
+            }
+        },
+        "is-number": {
+            "version": "7.0.0",
+            "resolved": "https://npm.shopee.io/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true
+        },
+        "is-what": {
+            "version": "3.14.1",
+            "resolved": "https://npm.shopee.io/is-what/-/is-what-3.14.1.tgz",
+            "integrity": "sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==",
+            "dev": true
+        },
         "jsonfile": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -387,6 +571,150 @@
             "requires": {
                 "graceful-fs": "^4.1.6",
                 "universalify": "^2.0.0"
+            }
+        },
+        "less": {
+            "version": "4.1.1",
+            "resolved": "https://npm.shopee.io/less/-/less-4.1.1.tgz",
+            "integrity": "sha512-w09o8tZFPThBscl5d0Ggp3RcrKIouBoQscnOMgFH3n5V3kN/CXGHNfCkRPtxJk6nKryDXaV9aHLK55RXuH4sAw==",
+            "dev": true,
+            "requires": {
+                "copy-anything": "^2.0.1",
+                "errno": "^0.1.1",
+                "graceful-fs": "^4.1.2",
+                "image-size": "~0.5.0",
+                "make-dir": "^2.1.0",
+                "mime": "^1.4.1",
+                "needle": "^2.5.2",
+                "parse-node-version": "^1.0.1",
+                "source-map": "~0.6.0",
+                "tslib": "^1.10.0"
+            }
+        },
+        "make-dir": {
+            "version": "2.1.0",
+            "resolved": "https://npm.shopee.io/make-dir/-/make-dir-2.1.0.tgz",
+            "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "pify": "^4.0.1",
+                "semver": "^5.6.0"
+            }
+        },
+        "mime": {
+            "version": "1.6.0",
+            "resolved": "https://npm.shopee.io/mime/-/mime-1.6.0.tgz",
+            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+            "dev": true,
+            "optional": true
+        },
+        "ms": {
+            "version": "2.1.3",
+            "resolved": "https://npm.shopee.io/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
+            "optional": true
+        },
+        "nanoid": {
+            "version": "3.1.23",
+            "resolved": "https://npm.shopee.io/nanoid/-/nanoid-3.1.23.tgz",
+            "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+            "dev": true
+        },
+        "needle": {
+            "version": "2.6.0",
+            "resolved": "https://npm.shopee.io/needle/-/needle-2.6.0.tgz",
+            "integrity": "sha512-KKYdza4heMsEfSWD7VPUIz3zX2XDwOyX2d+geb4vrERZMT5RMU6ujjaD+I5Yr54uZxQ2w6XRTAhHBbSCyovZBg==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "debug": "^3.2.6",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+            }
+        },
+        "normalize-path": {
+            "version": "3.0.0",
+            "resolved": "https://npm.shopee.io/normalize-path/-/normalize-path-3.0.0.tgz",
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+            "dev": true
+        },
+        "parse-node-version": {
+            "version": "1.0.1",
+            "resolved": "https://npm.shopee.io/parse-node-version/-/parse-node-version-1.0.1.tgz",
+            "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.6",
+            "resolved": "https://npm.shopee.io/path-parse/-/path-parse-1.0.6.tgz",
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+            "dev": true
+        },
+        "picomatch": {
+            "version": "2.2.3",
+            "resolved": "https://npm.shopee.io/picomatch/-/picomatch-2.2.3.tgz",
+            "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
+            "dev": true
+        },
+        "pify": {
+            "version": "4.0.1",
+            "resolved": "https://npm.shopee.io/pify/-/pify-4.0.1.tgz",
+            "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+            "dev": true,
+            "optional": true
+        },
+        "postcss": {
+            "version": "8.2.15",
+            "resolved": "https://npm.shopee.io/postcss/-/postcss-8.2.15.tgz",
+            "integrity": "sha512-2zO3b26eJD/8rb106Qu2o7Qgg52ND5HPjcyQiK2B98O388h43A448LCslC0dI2P97wCAQRJsFvwTRcXxTKds+Q==",
+            "dev": true,
+            "requires": {
+                "colorette": "^1.2.2",
+                "nanoid": "^3.1.23",
+                "source-map": "^0.6.1"
+            }
+        },
+        "postcss-pxtorem": {
+            "version": "6.0.0",
+            "resolved": "https://npm.shopee.io/postcss-pxtorem/-/postcss-pxtorem-6.0.0.tgz",
+            "integrity": "sha512-ZRXrD7MLLjLk2RNGV6UA4f5Y7gy+a/j1EqjAfp9NdcNYVjUMvg5HTYduTjSkKBkRkfqbg/iKrjMO70V4g1LZeg==",
+            "dev": true
+        },
+        "prr": {
+            "version": "1.0.1",
+            "resolved": "https://npm.shopee.io/prr/-/prr-1.0.1.tgz",
+            "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+            "dev": true,
+            "optional": true
+        },
+        "readdirp": {
+            "version": "3.5.0",
+            "resolved": "https://npm.shopee.io/readdirp/-/readdirp-3.5.0.tgz",
+            "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+            "dev": true,
+            "requires": {
+                "picomatch": "^2.2.1"
+            }
+        },
+        "resolve": {
+            "version": "1.20.0",
+            "resolved": "https://npm.shopee.io/resolve/-/resolve-1.20.0.tgz",
+            "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+            "dev": true,
+            "requires": {
+                "is-core-module": "^2.2.0",
+                "path-parse": "^1.0.6"
+            }
+        },
+        "rollup": {
+            "version": "2.48.0",
+            "resolved": "https://npm.shopee.io/rollup/-/rollup-2.48.0.tgz",
+            "integrity": "sha512-wl9ZSSSsi5579oscSDYSzGn092tCS076YB+TQrzsGuSfYyJeep8eEWj0eaRjuC5McuMNmcnR8icBqiE/FWNB1A==",
+            "dev": true,
+            "requires": {
+                "fsevents": "~2.3.1"
             }
         },
         "sade": {
@@ -402,6 +730,57 @@
                 }
             }
         },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://npm.shopee.io/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true,
+            "optional": true
+        },
+        "sass": {
+            "version": "1.32.13",
+            "resolved": "https://npm.shopee.io/sass/-/sass-1.32.13.tgz",
+            "integrity": "sha512-dEgI9nShraqP7cXQH+lEXVf73WOPCse0QlFzSD8k+1TcOxCMwVXfQlr0jtoluZysQOyJGnfr21dLvYKDJq8HkA==",
+            "dev": true,
+            "requires": {
+                "chokidar": ">=3.0.0 <4.0.0"
+            }
+        },
+        "sax": {
+            "version": "1.2.4",
+            "resolved": "https://npm.shopee.io/sax/-/sax-1.2.4.tgz",
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+            "dev": true,
+            "optional": true
+        },
+        "semver": {
+            "version": "5.7.1",
+            "resolved": "https://npm.shopee.io/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "dev": true,
+            "optional": true
+        },
+        "source-map": {
+            "version": "0.6.1",
+            "resolved": "https://npm.shopee.io/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true
+        },
+        "to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://npm.shopee.io/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
+            "requires": {
+                "is-number": "^7.0.0"
+            }
+        },
+        "tslib": {
+            "version": "1.14.1",
+            "resolved": "https://npm.shopee.io/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
+        },
         "typescript": {
             "version": "4.2.4",
             "dev": true
@@ -410,6 +789,19 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
             "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+        },
+        "vite": {
+            "version": "2.3.2",
+            "resolved": "https://npm.shopee.io/vite/-/vite-2.3.2.tgz",
+            "integrity": "sha512-QhLdOompDrfkyryCNTts9HE+eJhvhN9ibKNJ5Q8DpQai+6nOsuIlaveZNg67e1O/2QaWqXeBo82eHnAs1De2bQ==",
+            "dev": true,
+            "requires": {
+                "esbuild": "^0.11.20",
+                "fsevents": "~2.3.1",
+                "postcss": "^8.2.10",
+                "resolve": "^1.19.0",
+                "rollup": "^2.38.5"
+            }
         }
     }
 }

--- a/packages/quickpage/package.json
+++ b/packages/quickpage/package.json
@@ -4,8 +4,8 @@
     "description": "",
     "main": "lib/index.js",
     "files": [
-       "lib",
-       "template"
+        "lib",
+        "template"
     ],
     "scripts": {
         "prepare": "tsc"

--- a/packages/quickpage/src/create.ts
+++ b/packages/quickpage/src/create.ts
@@ -2,6 +2,21 @@ import * as utils from './utils';
 import path from 'path';
 import { copySync, pathExistsSync } from 'fs-extra';
 
+const getTemplate = (choice: string) => {
+  const mappings = [
+    {
+      choice: 'vanilla(html + javascript + css)',
+      value: 'vanilla',
+    },
+    {
+      choice: 'vanilla-ts(html + typescript + less)',
+      value: 'vanilla-ts',
+    },
+  ];
+  const res = mappings.find(s => s.choice === choice);
+  return res?.value;
+};
+
 export const create = async () => {
   // ask for project name
   try {
@@ -34,7 +49,10 @@ export const create = async () => {
     });
 
     await utils.createDir(base); // 创建根目录
-    copySync(path.join(__dirname, `../template/${tpl.value}`), base);
+    copySync(
+      path.join(__dirname, `../template/${getTemplate(tpl.value)}`),
+      base
+    );
   } catch (err) {
     utils.info(String(err), 'ERROR');
   }

--- a/packages/quickpage/src/dev.ts
+++ b/packages/quickpage/src/dev.ts
@@ -1,6 +1,6 @@
 import { readdirSync } from 'fs-extra';
 import { createServer } from 'vite';
-import { prompt, info } from './utils';
+import { prompt, info, loadViteConfig } from './utils';
 import { join } from 'path';
 
 export const dev = async () => {
@@ -15,8 +15,7 @@ export const dev = async () => {
     const cwd = process.cwd();
 
     const server = await createServer({
-      // 任何合法的用户配置选项，加上 `mode` 和 `configFile`
-      configFile: false,
+      configFile: loadViteConfig(),
       root: join(cwd, 'pages', projectName.value),
       server: {
         port: 3333,

--- a/packages/quickpage/src/utils.ts
+++ b/packages/quickpage/src/utils.ts
@@ -69,6 +69,16 @@ function resolve(_path: string) {
   return path.resolve(cwd, _path);
 }
 
+function loadViteConfig(configRoot: string = process.cwd()) {
+  let resolvedPath = '';
+  const jsconfigFile = path.resolve(configRoot, 'vite.config.js');
+  if (fs.existsSync(jsconfigFile)) {
+    resolvedPath = jsconfigFile;
+  }
+
+  return resolvedPath || undefined;
+}
+
 export {
   writeFile,
   createDir,
@@ -78,4 +88,5 @@ export {
   prompt,
   input,
   info,
+  loadViteConfig,
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
       /* Basic Options */
       // "incremental": true,                   /* Enable incremental compilation */
-      "target": "ESNext",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+      "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
       // "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
       // "lib": [],                             /* Specify library files to be included in the compilation. */
       // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
1. fix: 🐛 create template name. When creating a template name, the template name cannot be matched.

template name is vanilla and vanilla-ts

but the choices are as below

```javascript
choices: [
        {
          name: 'vanilla(html + javascript + css)',
        },
        {
          name: 'vanilla-ts(html + typescript + less)',
        },
      ],
```

2. Read vite.config.js from project root path